### PR TITLE
feat: add support for more complex schemas and enums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 import type { SchemaDefinition } from "mongoose";
 import * as Mongoose from "mongoose";
-import { ZodFirstPartyTypeKind, type z, type ZodArray, type ZodObject, type ZodRawShape } from "zod";
+import {
+	EnumLike,
+	ZodFirstPartyTypeKind,
+	type z,
+	type ZodArray,
+	type ZodNativeEnum,
+	type ZodObject,
+	type ZodRawShape,
+} from "zod";
 
 import type { SupportedType } from "./types";
 
@@ -10,23 +18,7 @@ import type { SupportedType } from "./types";
  *
  * @internal
  */
-type MongooseSchemaType =
-	| Mongoose.Schema
-	| MongooseSchemaType[]
-	| typeof Boolean
-	| typeof Date
-	| typeof Number
-	// This covers both a schema definition for a sub-document and the empty
-	// object `{}` used for Mixed types.
-	| typeof String
-	// This covers an array of sub-documents or an array of primitives.
-	// Mongoose expects an array with a single element defining the type.
-	| { [key: string]: MongooseSchemaType }
-	// This covers the object format for specifying a default value.
-	| {
-			default?: unknown;
-			type: MongooseSchemaType;
-	  };
+type MongooseSchemaType = Mongoose.SchemaDefinitionProperty;
 export function createSchema<T extends ZodRawShape>(
 	zodObject: ZodObject<T>,
 	modelName: string,
@@ -91,8 +83,10 @@ function convertField<T extends ZodRawShape>(type: string, zodField: T[Extract<k
 		case ZodFirstPartyTypeKind.ZodDate:
 			coreType = Date;
 			break;
+		case ZodFirstPartyTypeKind.ZodDefault:
+			break;
 		case ZodFirstPartyTypeKind.ZodEnum: {
-			const enumType = unwrappedData.definition as z.ZodEnum<[string, ...string[]]>;
+			const enumType = unwrappedData.definition as unknown as z.ZodEnum<[string, ...string[]]>;
 			coreType = {
 				enum: enumType.options,
 				type: String,
@@ -100,9 +94,9 @@ function convertField<T extends ZodRawShape>(type: string, zodField: T[Extract<k
 			break;
 		}
 		case ZodFirstPartyTypeKind.ZodNativeEnum: {
-			const enumType = unwrappedData.definition as z.ZodNativeEnum<Record<string, unknown>>;
+			const enumType = unwrappedData.definition as unknown as ZodNativeEnum<EnumLike>;
 			coreType = {
-				enum: Object.values(enumType.enum),
+				enum: getValidEnumValues(enumType.enum),
 				type: String,
 			};
 			break;
@@ -116,7 +110,7 @@ function convertField<T extends ZodRawShape>(type: string, zodField: T[Extract<k
 			coreType = String;
 			break;
 		case ZodFirstPartyTypeKind.ZodUnion:
-			coreType = {};
+			coreType = Mongoose.SchemaTypes.Mixed;
 			break;
 		default:
 			throw new TypeError(`Unsupported type: ${type}`);
@@ -155,6 +149,27 @@ function convertField<T extends ZodRawShape>(type: string, zodField: T[Extract<k
 function isZodObject(definition: SupportedType): definition is ZodObject<ZodRawShape> {
 	return definition._def.typeName === ZodFirstPartyTypeKind.ZodObject;
 }
+function isZodDefault(definition: z.ZodTypeAny): definition is z.ZodDefault<SupportedType> {
+	return definition._def.typeName === ZodFirstPartyTypeKind.ZodDefault;
+}
+
+function isZodNullable(definition: z.ZodTypeAny): definition is z.ZodNullable<SupportedType> {
+	return definition._def.typeName === ZodFirstPartyTypeKind.ZodNullable;
+}
+
+function isZodOptional(definition: z.ZodTypeAny): definition is z.ZodOptional<SupportedType> {
+	return definition._def.typeName === ZodFirstPartyTypeKind.ZodOptional;
+}
+
+function getValidEnumValues(obj: { [s: string]: unknown }): (string | number)[] {
+	const validKeys = Object.keys(obj).filter((k) => typeof obj[k] === "number" || typeof obj[k] === "string");
+	const filtered: { [s: string]: unknown } = {};
+	for (const k of validKeys) {
+		filtered[k] = obj[k];
+	}
+
+	return Object.values(filtered).filter((v) => typeof v === "string" || typeof v === "number");
+}
 
 /**
  * Takes a complex type and returns the inner type definition along with the default if present.
@@ -173,13 +188,13 @@ function unwrapType(data: SupportedType): {
 	let optional = false;
 	let defaultValue: unknown | undefined;
 	while ("innerType" in definition._def) {
-		if (definition._def.typeName === ZodFirstPartyTypeKind.ZodNullable) {
+		if (isZodNullable(definition)) {
 			nullable = true;
 		}
-		if (definition._def.typeName === ZodFirstPartyTypeKind.ZodOptional) {
+		if (isZodOptional(definition)) {
 			optional = true;
 		}
-		if ("defaultValue" in definition._def) {
+		if (isZodDefault(definition)) {
 			defaultValue = definition._def.defaultValue();
 		}
 		definition = definition._def.innerType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,15 @@
 import type {
+	EnumLike,
 	ZodArray,
 	ZodBoolean,
 	ZodDate,
 	ZodDefault,
+	ZodEnum,
+	ZodNativeEnum,
+	ZodNullable,
 	ZodNumber,
 	ZodObject,
+	ZodOptional,
 	ZodRawShape,
 	ZodString,
 	ZodTypeAny,
@@ -28,6 +33,10 @@ export type SupportedType =
 	| SupportedPrimitive
 	| ZodArray<ZodTypeAny>
 	| ZodDefault<ZodTypeAny>
+	| ZodEnum<[string, ...string[]]>
+	| ZodNativeEnum<EnumLike>
+	| ZodNullable<ZodTypeAny>
 	| ZodObject<ZodRawShape>
+	| ZodOptional<ZodTypeAny>
 	| ZodUnion<readonly [ZodTypeAny, ...ZodTypeAny[]]>;
 type SupportedPrimitive = ZodBoolean | ZodDate | ZodNumber | ZodString;

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -26,6 +26,7 @@ vi.mock("mongoose", () => {
 		Schema: vi.fn((schemaDefinition) => ({
 			obj: schemaDefinition, // Store the schema definition for access
 		})),
+		SchemaTypes: { Mixed: {} },
 	};
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,0 +1,90 @@
+import mongoose, { type SchemaDefinition } from "mongoose";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createSchema } from "../src";
+
+vi.mock("mongoose", () => {
+	return {
+		default: {
+			connection: {
+				model: vi.fn((_name, schema) => ({
+					create: vi.fn((doc) => {
+						const result = { _id: "123456789012345678901234", ...doc };
+						// Apply default values from the schema
+						for (const [key, value] of Object.entries(schema.obj)) {
+							if (typeof value === "object" && value) {
+								if ("default" in value && value.default !== undefined && result[key] === undefined) {
+									result[key] = typeof value.default === "function" ? value.default() : value.default;
+								}
+							}
+						}
+						return Promise.resolve(result);
+					}),
+				})),
+			},
+		},
+		Schema: vi.fn((schemaDefinition) => ({
+			obj: schemaDefinition, // Store the schema definition for access
+		})),
+	};
+});
+
+describe("Complex Schemas", () => {
+	it("should handle the customPropertyMapping schema", () => {
+		const CustomPropertyMappingSchema = z.object({
+			sectionTitle: z.string().optional(),
+			propertyKey: z.string(),
+			displayTitle: z.string(),
+			type: z.enum(["text", "enum-single", "enum-multi"]),
+			enum_options: z.array(z.string()).optional(),
+			useCase: z.enum(["edit", "readOnly"]),
+			required: z.boolean().optional(),
+		});
+
+		const TestSchema = z.object({
+			customPropertyMapping: z.array(CustomPropertyMappingSchema).optional(),
+		});
+
+		const { schema } = createSchema(TestSchema, "complex", mongoose.connection);
+		expect(schema.obj.customPropertyMapping).toBeDefined();
+		if (!schema.obj.customPropertyMapping) return;
+		const customPropertyMapping = (schema.obj.customPropertyMapping as SchemaDefinition[])[0];
+		expect(customPropertyMapping.type).toEqual({ type: String, enum: ["text", "enum-single", "enum-multi"] });
+		expect(customPropertyMapping.useCase).toEqual({ type: String, enum: ["edit", "readOnly"] });
+	});
+});
+
+describe("Nullable Schemas", () => {
+	it("should handle nullable fields", () => {
+		const NullableSchema = z.object({
+			deletedAt: z.string().optional().nullable(),
+		});
+
+		const { schema } = createSchema(NullableSchema, "nullable", mongoose.connection);
+		expect(schema.obj.deletedAt).toEqual({ type: String, default: null });
+	});
+
+	it("should handle nullable and optional fields", () => {
+		const NullableSchema = z.object({
+			deletedAt: z.string().nullable().optional(),
+		});
+
+		const { schema } = createSchema(NullableSchema, "nullable-optional", mongoose.connection);
+		expect(schema.obj.deletedAt).toEqual({ type: String, default: null });
+	});
+});
+
+describe("Native Enums", () => {
+	it("should handle native enums", () => {
+		enum UseCase {
+			edit = "edit",
+			readOnly = "readOnly",
+		}
+		const NativeEnumSchema = z.object({
+			useCase: z.nativeEnum(UseCase),
+		});
+
+		const { schema } = createSchema(NativeEnumSchema, "native-enum", mongoose.connection);
+		expect(schema.obj.useCase).toEqual({ type: String, enum: ["edit", "readOnly"] });
+	});
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,6 +27,7 @@ vi.mock("mongoose", () => {
 		Schema: vi.fn((schemaDefinition) => ({
 			obj: schemaDefinition, // Store the schema definition for access
 		})),
+		SchemaTypes: { Mixed: {} },
 	};
 });
 


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of Zod schemas when converting them to Mongoose schemas, especially regarding enum, nullable, and optional types. It also expands type support in the codebase and adds comprehensive tests to ensure correctness for these more complex schema features.

**Schema conversion enhancements:**

* Added support for Zod enums (`z.enum`) and native enums (`z.nativeEnum`) by mapping them to Mongoose schema fields with appropriate `enum` and `type` properties, ensuring correct validation and storage in MongoDB. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R86-R103) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L3-R11) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR2-R12) [[4]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR36-R40)
* Improved handling of nullable and optional fields, so that fields defined as `.nullable()` or `.optional().nullable()` in Zod schemas are correctly mapped to Mongoose fields with `default: null` where appropriate. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L114-R141) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R152-R202) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR36-R40)

**Type and internal refactoring:**

* Simplified the `MongooseSchemaType` type to use `Mongoose.SchemaDefinitionProperty`, reducing complexity and improving maintainability.
* Refactored internal unwrapping logic to properly track `nullable`, `optional`, and `defaultValue` properties, ensuring accurate schema conversion.

**Testing improvements:**

* Added new test suites in `features.test.ts` to verify correct handling of enums, native enums, nullable, and optional fields in the schema conversion logic.
* Updated mocks in test setup to support new schema features and types. [[1]](diffhunk://#diff-cece62ae24396a5d51e8f2a2cb3abba900652084488023f4de9669eaaf6f81e8R30) [[2]](diffhunk://#diff-2bf2f7caf9d0fee81e19dafc16df4aefcd3dde02b3b2b23742376f5cd3b141d5R1-R91)

These changes make the conversion between Zod and Mongoose schemas more robust and feature-complete, especially for projects using advanced Zod features.